### PR TITLE
[patch] add new jsx-a11y rule and removed empty global setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ module.exports = {
     ...globalEnv
   },
   extends: ["airbnb-base", ...globalExtensions],
-  globals: {},
   plugins: [...globalPlugins],
   rules: {
     ...globalRules

--- a/react-config.js
+++ b/react-config.js
@@ -15,12 +15,11 @@ module.exports = {
     ...globalEnv
   },
   extends: ["airbnb", ...globalExtensions],
-  global: {},
   parser: globalParser,
   plugins: ["cypress", ...globalPlugins],
   rules: {
     ...globalRules,
-    "jsx-a11y/href-no-hash": "warn",
+    "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
     "react/jsx-filename-extension": "warn",
     "react/forbid-prop-types": "warn",


### PR DESCRIPTION
Our dependency jsx-a11y v6.x removed the rule "href-no-hash". A similar rule, "anchor-is-valid", is now used. This PR updates our react-config to use this new rule and remove the old one.

This PR also removes the "global" property as it's empty and seems to throw an error.

