### PR TITLE
add rule to allow js and jsx react extensions

### DIFF
--- a/react-config.js
+++ b/react-config.js
@@ -22,6 +22,7 @@ module.exports = {
     "jsx-a11y/no-static-element-interactions": "warn",
     "react/jsx-filename-extension": "warn",
     "react/forbid-prop-types": "warn",
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-no-bind": "error",
     "react/jsx-no-target-blank": "warn",
     "react/no-danger": "warn",


### PR DESCRIPTION
We can use either extensions, preferably `js` for react component. OMS and APP use `js` already

 "react/jsx-filename-extension": [1, { "extensions": [".js"] }],