### PR TITLE
[major] add autofix for import sorting, possible to break code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -910,6 +910,14 @@
         "resolve": "^1.10.1"
       }
     },
+    "eslint-plugin-sort-imports-es6-autofix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.4.0.tgz",
+      "integrity": "sha512-LyqXwY0TIu997NdTbSPtTo3KgGRrpMLni4AUxqbQqkhE/kS+KXXngHoiW5c1PTaLgmHO6siBb90v1TCtyqBu/Q==",
+      "requires": {
+        "eslint": "^5.14.1"
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ahmdigital/eslint-config.git"
   },
   "author": "ahm Digital <AHM.Digital.Team@medibank.com.au>",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ahmdigital/eslint-config/issues"
   },
@@ -30,6 +30,7 @@
     "eslint-plugin-lodash": "5.1.0",
     "eslint-plugin-prettier": "3.1.0",
     "eslint-plugin-react": "7.14.3",
+    "eslint-plugin-sort-imports-es6-autofix": "^0.4.0",
     "prettier": "1.18.2"
   },
   "engines": {

--- a/react-config.js
+++ b/react-config.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   extends: ['airbnb', ...globalExtensions, 'prettier/react'],
   parser: globalParser,
-  plugins: ['cypress', ...globalPlugins],
+  plugins: ['sort-imports-es6-autofix', 'cypress', ...globalPlugins],
   rules: {
     ...globalRules,
     'jsx-a11y/anchor-is-valid': 'warn',
@@ -31,6 +31,14 @@ module.exports = {
     'react/prefer-stateless-function': 'warn',
     'react/prop-types': 'error',
     'react/require-default-props': 'warn',
+    'sort-imports-es6-autofix/sort-imports-es6': [
+      'error',
+      {
+        ignoreCase: true,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
+      }
+    ],
   },
   settings: {
     ...globalSettings,


### PR DESCRIPTION
Its a pain to manually sort stuff.

https://github.com/marudor/eslint-plugin-sort-imports-es6-autofix

https://github.com/lydell/eslint-plugin-simple-import-sort

both can autosort (just `import`s, sorry requires!)

Lets use the top one since its more popular and agrees more with our current methodology (second one sorts on right-side)

Main difference from our currently agreed standard is that multi-imports will always be before `_` for lodash.

<img width="1208" alt="image" src="https://user-images.githubusercontent.com/4197647/61918169-cd3ea980-af93-11e9-8889-a5ff5204ecf4.png">


BREAKING: Technically this has a possibility of breaking something. I'm comfy with this risk since we have good tests. Think about the time you deploy this though, no friday arvo deployments :).