### PR TITLE
[patch] use prettier > eslint for format

### DIFF
--- a/global-config.js
+++ b/global-config.js
@@ -22,7 +22,10 @@ module.exports = {
     'import/order': [
       'error',
       {
-        groups: [['builtin', 'external'], ['parent', 'sibling', 'index']],
+        groups: [
+          ['builtin', 'external'],
+          ['parent', 'sibling', 'index'],
+        ],
         'newlines-between': 'always',
       },
     ],

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   env: {
     ...globalEnv,
   },
-  extends: ['airbnb-base', ...globalExtensions],
+  extends: ['airbnb-base', 'plugin:prettier/recommended', ...globalExtensions],
   plugins: [...globalPlugins],
   rules: {
     ...globalRules,


### PR DESCRIPTION
This has been annoying me casually for months. We want eslint to enforce best practices and prettier to format our code, this change should default prettier as the format preference and they should stop fighting.