### PR TITLE
[patch] warn, not warning

### DIFF
--- a/global-config.js
+++ b/global-config.js
@@ -56,7 +56,7 @@ module.exports = {
     'lodash/prefer-constant': ['error', false],
     'lodash/prefer-lodash-method': ['error', { ignoreMethods: ['find', 'startsWith'] }],
     'lodash/prefer-over-quantifier': 'off',
-    'lodash-fp/use-fp': 'warning',
+    'lodash-fp/use-fp': 'warn',
     'new-parens': 'error',
     'no-alert': 'error',
     'no-console': 'error',


### PR DESCRIPTION
Last one, I swear. Updating `warning` to the correctly required `warn`.