### PR TITLE
[patch] fix homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint . --fix"
   },
-  "homepage": "https://github.com/ahmdigital/eslint-config#readme",
+  "homepage": "https://github.com/ahmdigital/eslint-config",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "5.40.0",
     "@typescript-eslint/parser": "5.40.0",


### PR DESCRIPTION
Remove redundant `#readme` from homepage url, this will fix the Slack release message URLs.

![Screen Shot 2022-10-17 at 09 04 25](https://user-images.githubusercontent.com/908155/196060536-d376b38b-78a4-47ec-9081-56465c7d55ee.png)