### PR TITLE
ESD-41: [patch] fix dockerfile npm override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /root/app/
 RUN apt-get update \
   && apt-get install -y jq
 
-RUN npm i -g npm@latest
 COPY package.json package-lock.json ./
 RUN npm ci --quiet --no-optional && npm cache clean --force
 

--- a/react-config.js
+++ b/react-config.js
@@ -23,6 +23,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react/forbid-prop-types': 'warn',
+    "react/function-component-definition": [2, { "namedComponents": "arrow-function" }],
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     'react/jsx-fragments': 'off',
     'react/jsx-no-bind': 'error',


### PR DESCRIPTION
Jira issue: [ESD-41](https://medibank.atlassian.net/browse/ESD-41)
---

#### What does this PR do?

Dockerfile was overriding the npm version causing issues with the build pipeline. This PR removes the override.

[ESD-41]: https://medibank.atlassian.net/browse/ESD-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ